### PR TITLE
Add student self-enrollment for subjects

### DIFF
--- a/code/src/main/java/com/is1/proyecto/App.java
+++ b/code/src/main/java/com/is1/proyecto/App.java
@@ -2,6 +2,8 @@ package com.is1.proyecto;
 
 import com.is1.proyecto.config.DBConfigSingleton;
 import com.is1.proyecto.routes.*;
+
+
 import org.javalite.activejdbc.Base;
 import java.io.BufferedReader;
 import java.io.IOException;
@@ -38,6 +40,7 @@ public class App {
         new StudyPlanRoutes().register();
         new ProfessorSubjectRoutes().register();
         new RegistrationSubjectRoutes().register();
+        new StudentSubjectRoutes().register();
         CareerStudentRoutes.register();
         new ProfessorDashboardRoutes().register();
         new GradeRoutes().register();

--- a/code/src/main/java/com/is1/proyecto/controllers/StudentSubjectController.java
+++ b/code/src/main/java/com/is1/proyecto/controllers/StudentSubjectController.java
@@ -1,0 +1,131 @@
+package com.is1.proyecto.controllers;
+
+import com.is1.proyecto.models.Person;
+import com.is1.proyecto.models.RegistrationSubject;
+import com.is1.proyecto.models.Subject;
+import com.is1.proyecto.services.RegistrationSubjectService;
+import com.is1.proyecto.services.ServiceException;
+import com.is1.proyecto.services.dto.RegistrationSubjectCreateDTO;
+
+import spark.ModelAndView;
+import spark.Request;
+import spark.Response;
+import spark.template.mustache.MustacheTemplateEngine;
+
+import java.util.*;
+
+public class StudentSubjectController extends BaseController {
+
+    private final RegistrationSubjectService registrationService;
+
+    public StudentSubjectController(
+            RegistrationSubjectService registrationService,
+            MustacheTemplateEngine templateEngine) {
+
+        super(templateEngine);
+        this.registrationService = registrationService;
+    }
+
+    public String showAvailableSubjects(Request req, Response res) {
+
+        Long userId = req.session().attribute("userId");
+
+        Person person = Person.findById(userId);
+
+        Map<String,Object> model = new HashMap<>();
+
+        try {
+
+            List<Subject> subjects =
+                registrationService.getAvailableSubjectsForStudent(
+                    person.getDni());
+
+            List<Map<String,Object>> subjectMaps = new ArrayList<>();
+
+            for (Subject s : subjects) {
+
+                Map<String,Object> m = new HashMap<>();
+
+                m.put("id", s.getLongId());
+                m.put("code", s.getCode());
+                m.put("name", s.getName());
+                m.put("hours", s.getHours());
+
+                subjectMaps.add(m);
+            }
+
+            model.put("subjects", subjectMaps);
+            model.put("hasSubjects", !subjectMaps.isEmpty());
+
+        } catch (Exception e) {
+
+            model.put("hasSubjects", false);
+            model.put("errorMessage", e.getMessage());
+        }
+
+        return templateEngine.render(
+            new ModelAndView(model, "student_subjects.mustache"));
+    }
+
+    public String enroll(Request req, Response res) {
+
+        Long userId = req.session().attribute("userId");
+
+        Person person = Person.findById(userId);
+
+        RegistrationSubjectCreateDTO dto =
+            new RegistrationSubjectCreateDTO();
+
+        dto.studentDni = person.getDni();
+
+        try {
+
+            dto.subjectId =
+                Long.parseLong(req.queryParams("subject_id"));
+
+            RegistrationSubject registration =
+                registrationService.create(dto);
+
+            res.redirect(
+                "/student/subjects/confirmation/" +
+                registration.getLongId());
+
+        } catch (ServiceException e) {
+
+            res.redirect(
+                "/student/subjects?error=" +
+                encode(e.getMessage()));
+
+        } catch (Exception e) {
+
+            res.redirect(
+                "/student/subjects?error=" +
+                encode("Error interno."));
+        }
+
+        return "";
+    }
+
+    public String showConfirmation(Request req, Response res) {
+
+        Long registrationId =
+            Long.parseLong(req.params(":id"));
+
+        RegistrationSubject registration =
+            RegistrationSubject.findById(registrationId);
+
+        Subject subject =
+            Subject.findById(registration.getSubjectId());
+
+        Map<String,Object> model = new HashMap<>();
+
+        model.put("subjectName", subject.getName());
+        model.put("subjectCode", subject.getCode());
+        model.put("date", registration.getDate());
+
+        return templateEngine.render(
+            new ModelAndView(
+                model,
+                "student_subject_confirmation.mustache"));
+    }
+}

--- a/code/src/main/java/com/is1/proyecto/routes/StudentSubjectRoutes.java
+++ b/code/src/main/java/com/is1/proyecto/routes/StudentSubjectRoutes.java
@@ -1,0 +1,59 @@
+package com.is1.proyecto.routes;
+
+import com.is1.proyecto.controllers.StudentSubjectController;
+import com.is1.proyecto.models.Person;
+import com.is1.proyecto.services.RegistrationSubjectService;
+
+import spark.Spark;
+import spark.template.mustache.MustacheTemplateEngine;
+
+public class StudentSubjectRoutes {
+
+    public void register() {
+
+        RegistrationSubjectService service =
+            new RegistrationSubjectService();
+
+        StudentSubjectController controller =
+            new StudentSubjectController(
+                service,
+                new MustacheTemplateEngine()
+            );
+
+        Spark.before("/student/subjects*", (req,res) -> {
+
+            Boolean loggedIn =
+                req.session().attribute("loggedIn");
+
+            if (loggedIn == null || !loggedIn) {
+
+                res.redirect("/login");
+                Spark.halt();
+            }
+
+            Long userId =
+                req.session().attribute("userId");
+
+            Person person =
+                Person.findById(userId);
+
+            if (person == null || !person.isStudent()) {
+
+                res.redirect("/dashboard");
+                Spark.halt();
+            }
+        });
+
+        Spark.get(
+            "/student/subjects",
+            controller::showAvailableSubjects);
+
+        Spark.post(
+            "/student/subjects/enroll",
+            controller::enroll);
+
+        Spark.get(
+            "/student/subjects/confirmation/:id",
+            controller::showConfirmation);
+    }
+}

--- a/code/src/main/resources/templates/dashboard_student.mustache
+++ b/code/src/main/resources/templates/dashboard_student.mustache
@@ -25,7 +25,7 @@
         <!-- Mis Inscripciones -->
         <div class="bg-green-50 border border-green-300 p-6 rounded-lg text-center shadow-md mb-6">
             <h2 class="text-xl font-semibold text-green-800 mb-2">Mis Inscripciones</h2>
-            <p class="text-gray-500 text-sm">Próximamente disponible.</p>
+            <a href="/student/subjects" class="inline-block bg-green-600 text-white py-2 px-6 rounded-full font-bold shadow-lg hover:bg-green-700 transition duration-300">Inscribirme en materias</a>
         </div>
 
         <!-- Historial Académico -->

--- a/code/src/main/resources/templates/student_subject_confirmation.mustache
+++ b/code/src/main/resources/templates/student_subject_confirmation.mustache
@@ -1,0 +1,19 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <title>Inscripción Exitosa</title>
+</head>
+<body>
+
+<h1>Inscripción realizada</h1>
+
+<p>Materia: {{subjectName}}</p>
+<p>Código: {{subjectCode}}</p>
+<p>Fecha: {{date}}</p>
+
+<a href="/dashboard/student">
+    Volver al dashboard
+</a>
+
+</body>
+</html>

--- a/code/src/main/resources/templates/student_subjects.mustache
+++ b/code/src/main/resources/templates/student_subjects.mustache
@@ -1,0 +1,45 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <title>Inscripción a Materias</title>
+    <script src="https://cdn.tailwindcss.com"></script>
+</head>
+<body class="p-8">
+
+<h1 class="text-2xl font-bold mb-6">
+    Materias disponibles
+</h1>
+
+{{#subjects}}
+<div class="border rounded p-4 mb-3">
+
+    <h2 class="font-bold">
+        {{name}}
+    </h2>
+
+    <p>Código: {{code}}</p>
+    <p>Horas: {{hours}}</p>
+
+    <form action="/student/subjects/enroll" method="post">
+
+        <input type="hidden"
+               name="subject_id"
+               value="{{id}}">
+
+        <button
+            class="bg-green-600 text-white px-4 py-2 rounded mt-2">
+
+            Inscribirme
+        </button>
+
+    </form>
+
+</div>
+{{/subjects}}
+
+{{^hasSubjects}}
+<p>No hay materias disponibles.</p>
+{{/hasSubjects}}
+
+</body>
+</html>


### PR DESCRIPTION
## Summary

Added functionality for students to self-enroll in subjects.

### Changes

* Added routes for student subject enrollment.
* Added controller to manage available subjects and enrollment flow.
* Added enrollment confirmation view.
* Updated student dashboard with access to subject enrollment.
* Reused existing RegistrationSubjectService business rules.

### Validation

* Project compiles successfully (`mvn clean compile`).
* Student users can view available subjects and enroll themselves.
